### PR TITLE
Fix warning display for raw when charList is not 6.

### DIFF
--- a/vestaboard/__init__.py
+++ b/vestaboard/__init__.py
@@ -75,9 +75,10 @@ class Board:
         charList.insert(0, base_filler)
     else:
       if pad == None:
-        # warnings.warn doesn't work with f strings
-        warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
-        warnings.warn(warning_message)
+        if len(charList) != 6:
+          # warnings.warn doesn't work with f strings
+          warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
+          warnings.warn(warning_message)
       while len(charList) < 6:
         charList.append(base_filler)
         if len(charList) < 6:

--- a/vestaboard/__init__.py
+++ b/vestaboard/__init__.py
@@ -62,7 +62,9 @@ class Board:
       for j, char in enumerate(row):
         if not isinstance(char, int):
           raise ValueError(f'Nested lists must contain numbers only - check row {i} char {j} (0 indexed)')
-    if len(charList) > 6:
+    if len(charList) == 6:
+      pass
+    elif len(charList) > 6:
       # warnings.warn doesn't work with f strings
       warning_message = f'The Vestaboard API accepts only 6 lines of characters; you\'ve passed in {len(charList)}. Only the first 6 will be shown.'
       warnings.warn(warning_message)
@@ -73,12 +75,10 @@ class Board:
     elif pad == 'above':
       for i in range(filler_needed):
         charList.insert(0, base_filler)
-    else:
-      if pad == None:
-        if len(charList) != 6:
-          # warnings.warn doesn't work with f strings
-          warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
-          warnings.warn(warning_message)
+    elif pad == None and len(charList) < 6:
+      # warnings.warn doesn't work with f strings
+      warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
+      warnings.warn(warning_message)
       while len(charList) < 6:
         charList.append(base_filler)
         if len(charList) < 6:

--- a/vestaboard/__init__.py
+++ b/vestaboard/__init__.py
@@ -69,20 +69,21 @@ class Board:
       warning_message = f'The Vestaboard API accepts only 6 lines of characters; you\'ve passed in {len(charList)}. Only the first 6 will be shown.'
       warnings.warn(warning_message)
       del charList[6:]
-    elif pad == 'below':
-      for i in range(filler_needed):
-        charList.append(base_filler)
-    elif pad == 'above':
-      for i in range(filler_needed):
-        charList.insert(0, base_filler)
-    elif pad == None and len(charList) < 6:
-      # warnings.warn doesn't work with f strings
-      warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
-      warnings.warn(warning_message)
-      while len(charList) < 6:
-        charList.append(base_filler)
-        if len(charList) < 6:
+    elif len(charList) < 6:
+      if pad == 'below':
+        for i in range(filler_needed):
+          charList.append(base_filler)
+      elif pad == 'above':
+        for i in range(filler_needed):
           charList.insert(0, base_filler)
+      elif pad == None:
+        # warnings.warn doesn't work with f strings
+        warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
+        warnings.warn(warning_message)
+        while len(charList) < 6:
+          charList.append(base_filler)
+          if len(charList) < 6:
+            charList.insert(0, base_filler)
     headers = {
         "X-Vestaboard-Api-Key" : self.apiKey,
         "X-Vestaboard-Api-Secret" : self.apiSecret

--- a/vestaboard/__init__.py
+++ b/vestaboard/__init__.py
@@ -76,10 +76,11 @@ class Board:
       elif pad == 'above':
         for i in range(filler_needed):
           charList.insert(0, base_filler)
-      elif pad == None:
-        # warnings.warn doesn't work with f strings
-        warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
-        warnings.warn(warning_message)
+      else:
+        if pad == None:
+          # warnings.warn doesn't work with f strings
+          warning_message = f'you provided a list with length {len(charList)}, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
+          warnings.warn(warning_message)
         while len(charList) < 6:
           charList.append(base_filler)
           if len(charList) < 6:


### PR DESCRIPTION
Only display the padding warning when using raw() and pad = none if the list is not 6.