### PR TITLE
Add error when instantiating `Board()` with a string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - '3.9'
 
 install:
+  - pip install -U setuptools
   - pip install -r requirements.txt
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
 python:
-  - '3.6'
   - '3.7'
   - '3.8'
   - '3.9'
 
 install:
-  - pip install -U setuptools
+  - pip install setuptools==60.8.2
   - pip install -r requirements.txt
   - pip install .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [v1.0.1](https://github.com/SonicRift/Vestaboard/releases/tag/v1.0.1) - 2022-06-18
+
+<small>[Compare with v1.0.0](https://github.com/SonicRift/Vestaboard/compare/v1.0.0...v1.0.1)</small>
+
+
+## [v1.0.0](https://github.com/SonicRift/Vestaboard/releases/tag/v1.0.0) - 2022-01-07
+
+<small>[Compare with v0.5.0](https://github.com/SonicRift/Vestaboard/compare/v0.5.0...v1.0.0)</small>
+
+
+## [v0.5.0](https://github.com/SonicRift/Vestaboard/releases/tag/v0.5.0) - 2021-02-22
+
+<small>[Compare with v0.4.0](https://github.com/SonicRift/Vestaboard/compare/v0.4.0...v0.5.0)</small>
+
+
+## [v0.4.0](https://github.com/SonicRift/Vestaboard/releases/tag/v0.4.0) - 2021-02-12
+
+<small>[Compare with v0.3.1](https://github.com/SonicRift/Vestaboard/compare/v0.3.1...v0.4.0)</small>
+
+
+## [v0.3.1](https://github.com/SonicRift/Vestaboard/releases/tag/v0.3.1) - 2021-02-10
+
+<small>[Compare with v0.2.0-beta](https://github.com/SonicRift/Vestaboard/compare/v0.2.0-beta...v0.3.1)</small>
+
+
+## [v0.2.0-beta](https://github.com/SonicRift/Vestaboard/releases/tag/v0.2.0-beta) - 2021-02-09
+
+<small>[Compare with first commit](https://github.com/SonicRift/Vestaboard/compare/049afbf9bbb45f5e6b5b797023729471ab6e653f...v0.2.0-beta)</small>
+
+

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ vboard.raw(characters)
 ![Board with raw input example](../media/rawexample.png?raw=true)
 
 ### New in Version 1.0.0
-The `.raw()` method now supports padding and truncating if more or fewer than 6 lines are provided! By default, your text will be centered vertically on the board, but will generate a warning (if an odd number of lines are provided, the additional line will be at the bottom). Supress this warning by passing in `pad='center'`. When passing in greater than 6 lines, the board will only display the first 6 lines.
+The `.raw()` method now supports padding and truncating if more or fewer than 6 lines are provided! By default, your text will be centered vertically on the board, but will generate a warning (if an odd number of lines are provided, the additional line will be at the bottom). Supress this warning by passing in `pad='center'`. When passing in greater than 6 lines, the board will only display the first 6 lines, removing lines from the bottom.
 
 You can also specify whether you'd like the padding to be added above or below your text by passing in `pad='top'` or `pad='bottom'` (only available when passing in < 6 lines). `pad='top'` will add padding above your text (your text will be at the bottom of the board), and `pad='bottom'` will add padding below your text (your text will be at the top of the board).
 
@@ -162,6 +162,7 @@ from vestaboard.formatter import Formatter
 Formatter().convert('Oh hi!')
 # Returns [15, 8, 0, 8, 9, 37]
 ```
+There is no limit to the number of letters you can convert. If you need to create a row with exactly 22 characters, you can use the `.convertLine()` method instead.
 
 To split by word, pass in the argument `byWord=True` along with your input string:
 
@@ -192,8 +193,8 @@ Formatter().convertLine('Happy Birthday!')
 ***
 ## Repository Info and Disclaimers
 ### Needs
--   Conversion from string to list of lists for `.raw()` method
--   Unit and other tests inside the `/test` folder
+-   ~~Conversion from string to list of lists for `.raw()` method~~ ✅ Complete!
+-   ~~Unit and other tests inside the `/test` folder~~ ✅ Complete!
 -   Suggestions or ideas for improvement are always welcome!
 
 Interested in contributing to this project? Send a PR with changes and I'd be happy to review! If you're having trouble with this library, be sure to [open an issue][] so that I can look into the problem. Any details that can be provided alongside the problem would be greatly appreciated.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/SonicRift/Vestaboard)
 ![GitHub contributors](https://img.shields.io/github/contributors/SonicRift/Vestaboard)
 
-This is a lightweight and unassuming wrapper for the Vestaboard API. This project is open source and no payment is necessary to use - project donations are always appreciated to help fund this effort. If interested, you can [ view the donation page here.](https://shanesutro.com/donate)
+This is a lightweight and unassuming wrapper for the Vestaboard API. This project is open source and no payment is necessary to use - project donations are always appreciated to help fund this effort. If interested, you can [view the donation page here.](https://shanesutro.com/donate)
 
 By [Shane Sutro][] and [contributors](https://github.com/SonicRift/Vestaboard/graphs/contributors)
 
@@ -37,15 +37,15 @@ Once created, you will need to store your API Key and API Secret - you'll need t
 -   Via `pip`:
 
 ```pip3 install vestaboard```
-_Note: if using a virtual environment, use `pip` instead of `pip3`_
+*Note: if using a virtual environment, use `pip` instead of `pip3`*
 
 #### Usage
 
 This package will simplify the process of connecting your code to Vestaboard's API.
 By default, the module will store your API Key, API Secret, and Subscriber ID in a .txt file in the root folder of the project.
-If you do _not_ want to store this, pass `saveCredentials=False` into the creation of an `Installable`. Alternatively, you may skip creating an `Installable` alltogether if you already know your Subscription ID (which you can get from Vestaboards official portal if you'd like to skip this step).
+If you do *not* want to store this, pass `saveCredentials=False` into the creation of an `Installable`. Alternatively, you may skip creating an `Installable` alltogether if you already know your Subscription ID (which you can get from Vestaboards official portal if you'd like to skip this step).
 
-If you do **_not_** know your Subscription ID call `Installable()` with your API Key and API Secret to find and store it:
+If you do *not* know your Subscription ID call `Installable()` with your API Key and API Secret to find and store it:
 ```python
 import vestaboard
 #This will print your subscription ID, and store all keys in 'credentials.txt'
@@ -87,7 +87,7 @@ Currently this module supports the following:
 
 -   Creating an instance of Board by passing in one of the following:
     -   An Installable, instantiated with API Key and API Secret
-    -   By passing in an API Key, API Secret _and_ Subscription ID directly to `Board()`
+    -   By passing in an API Key, API Secret *and* Subscription ID directly to `Board()`
     -   By passing in an Installable where `getSubscription=False` and manually providing the Subscription ID to `Board`.
 
 The board currently has 2 methods available, the `.post()` method, which takes in a string and sends it to the board, and the `.raw()` method, which allows you to place characters precisely where you'd like them.
@@ -105,7 +105,7 @@ vboard.post('Everything you can imagine is real.')
 
 The `.post()` method supports all letters and symbols that Vestaboard supports, including all letters, numbers, and symbols.
 In addition, you may pass in a character code in curly brackets to represent a single character or a color tile. You can view a reference of character and color codes on [Vestaboard's official website by clicking here.](https://docs.vestaboard.com/characters)
-Vestaboard's API currently strips leading and trailing spaces from lines - _this includes the `{0}` character (the black tile)_. To precisely place characters, use the `.raw()` method (see below).
+Vestaboard's API currently strips leading and trailing spaces from lines - *this includes the `{0}` character (the black tile)*. To precisely place characters, use the `.raw()` method (see below).
 
 ```python
 import vestaboard
@@ -145,7 +145,7 @@ The `.raw()` method now supports padding and truncating if more or fewer than 6 
 
 You can also specify whether you'd like the padding to be added above or below your text by passing in `pad='top'` or `pad='bottom'` (only available when passing in < 6 lines). `pad='top'` will add padding above your text (your text will be at the bottom of the board), and `pad='bottom'` will add padding below your text (your text will be at the top of the board).
 
----
+***
 
 To assist with character conversion, use the `Formatter` class.
 The `Formatter` has two public helper options:
@@ -202,7 +202,7 @@ Thanks!
 
 #### [Shane Sutro][]
 
-#### You belong here :heart:
+You belong here ♥️
 
 *Note: this project is maintaned by independent developers and is not sponsored by nor affiliated with Vestaboard, Inc. I am unable to make changes to their API or answer questions about the company, upcoming API support, or future-state plans. For questions regarding Vestaboard's API, privacy policies, or to request assistance with your board, [please get in touch with them here.](https://www.vestaboard.com/contact)*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.0.0
 requests==2.27.0
+setuptools==60.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pytest==7.0.0
 requests==2.27.0
-setuptools==60.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pytest==7.0.0
-requests==2.28.0
+requests==2.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,2 @@
-attrs==20.3.0
-certifi==2020.12.5
-chardet==4.0.0
-idna==2.10
-iniconfig==1.1.1
-packaging==20.9
-pluggy==0.13.1
-py==1.10.0
-pyparsing==2.4.7
-pytest==6.2.2
-requests==2.25.1
-toml==0.10.2
-urllib3==1.26.5
+pytest==7.0.0
+requests==2.28.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="Vestaboard",
-    version="0.5.0",
+    version="1.1.0",
     author="Shane Sutro",
     author_email="shane@shanesutro.com",
     description="A Vestaboard Wrapper",
@@ -18,9 +18,11 @@ setuptools.setup(
         'requests'
     ],
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
     ],
     python_requires='>=3.6',
 )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -137,42 +137,35 @@ def test_below_pad():
 def test_no_pad():
     small_board = return_valid_too_small_board()
     vb = create_fake_vestaboard()
-    vb.raw(small_board)
-    # warnings.warn doesn't work with f strings
-    warning_message = 'you provided a list with length 6, which has been centered on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
-    # tests if specific warning type and message is raised
-    with pytest.warns(UserWarning, match=warning_message):
-        warnings.warn(warning_message, UserWarning)
-    expected = [
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
-        [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    ]
-    assert small_board == expected
+    expected_warning = 'you provided a list with length 3, which has been centered vertically on the board by default. Either provide a list with length 6, or set the "pad" option to suppress this warning.'
+    with pytest.warns(UserWarning, match=expected_warning):
+        vb.raw(small_board)
+        expected = [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+            [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        ]
+        assert small_board == expected
 
 def test_large_board():
     large_board = return_valid_too_large_board()
     vb = create_fake_vestaboard()
-    vb.raw(large_board)
-    # warnings.warn doesn't work with f strings
-    warning_message = f'The Vestaboard API accepts only 6 lines of characters; you\'ve passed in {len(large_board)}. Only the first 6 will be shown.'
-    # tests if specific warning type and message is raised
-    with pytest.warns(UserWarning, match=warning_message):
-        warnings.warn(warning_message, UserWarning)
-    expected = [
-        [0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
-        [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
-        [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0, 0, 0]
-    ]
-    for i in large_board:
-        print(i)
-    assert large_board == expected
+    expected_warning = f'The Vestaboard API accepts only 6 lines of characters; you\'ve passed in {len(large_board)}. Only the first 6 will be shown.'
+
+    with pytest.warns(UserWarning, match=expected_warning):
+        vb.raw(large_board)
+        expected = [
+            [0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+            [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0],
+            [1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0, 0, 0]
+        ]
+        assert large_board == expected
 
 def create_fake_cred_file():
     with open(os.path.dirname(os.path.dirname(__file__)) + '/credentials.txt', 'w') as f:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,6 @@
 import vestaboard
 import pytest
 import os
-import warnings
 
 validRawChar = [
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
Added `ValueError` when `Board()` is instantiated with something other than a string as the first argument.

Also added information into the error as to how it should be fixed.
Resolves #26 