### PR TITLE
Fix some issues for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setuptools.setup(

--- a/vestaboard/__init__.py
+++ b/vestaboard/__init__.py
@@ -213,7 +213,7 @@ class Board:
         if self.localKey and self.localIP:
             self._raw_local(finalText["characters"])
         elif self.readWrite and self.apiKey:
-            headers = {"X-Vestaboard-Read-Write-Key": self.apiKey}
+            headers = {"X-Vestaboard-Read-Write-Key": self.apiKey, "Content-Type": "application/json"}
             requests.post(
                 vbUrls.readWrite,
                 headers=headers,


### PR DESCRIPTION
Hey, I was playing around with your library on my windows machine, and noticed the following:
1. I get a decode error when using pip to install locally from the long_description trying to read the README. Switching to a simple encoding fixes it and allows local installs on windows, but probably breaks other things (guessing it's the emoji characters)
    1. I can try reading it first unencoded, and only falling back if it fails
1. This one is weird - I assume a previous version of `requests` auto-set JSON content type or the Vestaboard API didn't enforce it, but it appears that it is enforcing now, or at least fails to post if JSON is not explicitly set. 

Let me know what you want me to do #2, I also didn't spend any time looking for other sites that potentially needed the content type set explicitly. 